### PR TITLE
Change deployment page Dockerfile example to use adduser

### DIFF
--- a/src/getting-started/deployment.md
+++ b/src/getting-started/deployment.md
@@ -53,7 +53,7 @@ COPY resources /app/resources
 # Not needed if you are using embed configuration
 COPY config.production.json ./config.production.json
 
-RUN useradd -r -U go-exec -M -d /app -s /bin/false
+RUN adduser -S go-exec 
 RUN chown -R go-exec /app
 
 USER go-exec

--- a/src/getting-started/deployment.md
+++ b/src/getting-started/deployment.md
@@ -53,7 +53,7 @@ COPY resources /app/resources
 # Not needed if you are using embed configuration
 COPY config.production.json ./config.production.json
 
-RUN adduser --system --home /app go-exec 
+RUN adduser --system --no-create-home --home /app go-exec 
 RUN chown -R go-exec /app
 
 USER go-exec

--- a/src/getting-started/deployment.md
+++ b/src/getting-started/deployment.md
@@ -53,7 +53,7 @@ COPY resources /app/resources
 # Not needed if you are using embed configuration
 COPY config.production.json ./config.production.json
 
-RUN adduser -S go-exec 
+RUN adduser --system --home /app go-exec 
 RUN chown -R go-exec /app
 
 USER go-exec


### PR DESCRIPTION
This change updates the example Dockerfile on the deployment page to use the command "adduser" instead of "useradd".

Alpine no longer works with useradd, so the original version fails.

The new version also uses the -S arg, which creates a system user, which is essentially the same as the args used for useradd in the original.

Fixes #23 