### PR TITLE
docs: tweaks to error printing and concurrency notes

### DIFF
--- a/src/basics/server.md
+++ b/src/basics/server.md
@@ -21,7 +21,7 @@ When the server is created:
 
 ## State
 
-The server state is an atomic number. The atomic nature of this state makes it concurrently safe, so any goroutine can read it easily. It allows the start and stop controls to be called from any goroutine.
+The server state is an atomic number. The atomic nature of this state makes it safe for concurrent use, so multiple goroutine can read it safely. It allows the start and stop controls to be called from any goroutine.
 
 The state is incremented for each stage:
 - `0` **Created**: the server was just created with `goyave.New()`
@@ -42,7 +42,7 @@ Startup hooks are executed in **a single goroutine** that they all share, in the
 ```go
 server, err := goyave.New(goyave.Options{})
 if err != nil {
-	fmt.Fprintln(os.Stderr, err.(*errors.Error).String())
+	fmt.Fprintln(os.Stderr, err.Error())
 	os.Exit(1)
 }
 
@@ -82,7 +82,7 @@ Shutdown hooks are therefore **blocking operations** and do not use a timeout me
 ```go
 server, err := goyave.New(goyave.Options{})
 if err != nil {
-	fmt.Fprintln(os.Stderr, err.(*errors.Error).String())
+	fmt.Fprintln(os.Stderr, err.Error())
 	os.Exit(1)
 }
 
@@ -98,7 +98,7 @@ You can register a OS signal hook that will listen on `SIGINT` and `SIGTERM` sig
 ```go
 server, err := goyave.New(goyave.Options{})
 if err != nil {
-	fmt.Fprintln(os.Stderr, err.(*errors.Error).String())
+	fmt.Fprintln(os.Stderr, err.Error())
 	os.Exit(1)
 }
 
@@ -118,7 +118,7 @@ Before starting your server, you need to regsiter your routes:
 ```go
 server, err := goyave.New(goyave.Options{})
 if err != nil {
-	fmt.Fprintln(os.Stderr, err.(*errors.Error).String())
+	fmt.Fprintln(os.Stderr, err.Error())
 	os.Exit(1)
 }
 
@@ -146,7 +146,7 @@ The error returned by `server.Start()` will always be of type `*goyave.dev/goyav
 
 ## Stop
 
-The server can be stopped manually from any goroutine. It is a concurrently safe operation.
+The server can be stopped manually from any goroutine. This function is safe for concurrent use.
 
 ```go
 server.Stop()
@@ -209,7 +209,7 @@ func TestDB(t *testing.T) {
 
 ### Manually replacing the database
 
-You can manually replace the database if need to, for example for mocking. **This is not concurrently safe** and should only be used in tests.
+You can manually replace the database if need to, for example for mocking. **This is not safe for concurrent use** and should only be used in tests.
 
 If a connection already exists, it is closed before being discarded.
 


### PR DESCRIPTION
This patch updates the error printing examples from calling `err.(*errors.Error).String()` to simply user `err.Error()` because although the former may work in these examples, it's a bad habit to obtain and may be copy-pasted; plus, the safe code is actually shorter anyway.

It also makes a minor language tweak of using the phrase "safe for concurrent use" to mimic the Go standard library documentation.